### PR TITLE
fix: issues with lib border

### DIFF
--- a/libs/border/src/lib.rs
+++ b/libs/border/src/lib.rs
@@ -39,7 +39,9 @@ impl<R: Runtime> WebviewWindowExt for WebviewWindow<R> {
 
         let content_view: id = unsafe { msg_send![handle, contentView] };
 
-        let view = BorderView::new(config, self.label().to_string());
+        let view = self
+            .border()
+            .unwrap_or(BorderView::new(config, self.label().to_string()));
 
         let frame = NSRect::new(
             NSPoint::new(0.0, 0.0),

--- a/libs/border/src/macos/border.rs
+++ b/libs/border/src/macos/border.rs
@@ -259,12 +259,6 @@ impl BorderView {
     pub fn remove(&self) {
         let () = unsafe { msg_send![self, removeFromSuperview] };
     }
-
-    pub fn destroy(&self) {
-        self.remove();
-
-        let () = unsafe { msg_send![self, release] };
-    }
 }
 
 unsafe impl Message for BorderView {}

--- a/libs/border/src/macos/border.rs
+++ b/libs/border/src/macos/border.rs
@@ -218,16 +218,22 @@ impl BorderView {
     #[allow(dead_code)]
     pub fn set_line_width(&self, width: CGFloat) {
         let () = unsafe { msg_send![self, setLineWidth: width] };
+
+        let () = unsafe { msg_send![self, display] };
     }
 
     #[allow(dead_code)]
     pub fn set_line_color(&self, color: Color) {
         let () = unsafe { msg_send![self, setLineColor: color.to_nscolor()] };
+
+        let () = unsafe { msg_send![self, display] };
     }
 
     #[allow(dead_code)]
     pub fn set_inset(&self, inset: CGFloat) {
         let () = unsafe { msg_send![self, setInset: inset] };
+
+        let () = unsafe { msg_send![self, display] };
     }
 
     #[allow(dead_code)]
@@ -237,6 +243,8 @@ impl BorderView {
         let layer: id = unsafe { msg_send![self, layer] };
 
         let () = unsafe { msg_send![layer, setCornerRadius: radius] };
+
+        let () = unsafe { msg_send![self, display] };
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
This pull request includes several changes to the `BorderView` implementation in the `libs/border/src/macos/border.rs` file and a modification to the `WebviewWindowExt` implementation in `libs/border/src/lib.rs`. The changes primarily focus on improving the display behavior of the border view and simplifying the codebase.

Improvements to display behavior:

* [`libs/border/src/macos/border.rs`](diffhunk://#diff-9f2452365024950eaa9927aa30144d934f00ebeaf77d31ba22c3a38a77c12efaR221-R236): Added calls to `display` after setting line width, line color, inset, and corner radius to ensure the border view updates immediately. [[1]](diffhunk://#diff-9f2452365024950eaa9927aa30144d934f00ebeaf77d31ba22c3a38a77c12efaR221-R236) [[2]](diffhunk://#diff-9f2452365024950eaa9927aa30144d934f00ebeaf77d31ba22c3a38a77c12efaR246-R247) [[3]](diffhunk://#diff-9f2452365024950eaa9927aa30144d934f00ebeaf77d31ba22c3a38a77c12efaL262-L267)

Codebase simplification:

* [`libs/border/src/macos/border.rs`](diffhunk://#diff-9f2452365024950eaa9927aa30144d934f00ebeaf77d31ba22c3a38a77c12efaL262-L267): Removed the `destroy` method from the `BorderView` implementation to simplify the code.

Modification to `WebviewWindowExt`:

* [`libs/border/src/lib.rs`](diffhunk://#diff-ce0923793c1db8f3d9ae87f90be0aeffa8ada4cfaf2b8ecfa9d47e24dcc1fe2bL42-R44): Updated the creation of the `BorderView` to use an existing border if available, or create a new one if not.