### PR TITLE
chore(docs): add link to example project

### DIFF
--- a/libs/border/README.md
+++ b/libs/border/README.md
@@ -30,6 +30,7 @@ border = { git = "https://github.com/ahkohd/tauri-toolkit", branch = "v2" }
 
 ![Border view demo](../../assets/border-demo-03.png)
 
+> See an example project of a window with a border [here](https://github.com/ahkohd/tauri-macos-window-border-example)
 
 ## Usage
 A basic usage:


### PR DESCRIPTION
This pull request includes a small change to the `libs/border/README.md` file. The change adds a link to an example project demonstrating a window with a border.

* [`libs/border/README.md`](diffhunk://#diff-dffda44c262e5374ea5cc3284337355b5d99d750120cf42d9231d576ea92aec6R33): Added a link to an example project of a window with a border.