### PR TITLE
chore(docs): remove method

### DIFF
--- a/libs/border/README.md
+++ b/libs/border/README.md
@@ -96,6 +96,8 @@ The `WebviewWindowExt` trait from the `border` crate when in scope adds the foll
   Adds a border view around the `WebviewWindow`. If options is `None`, the default options are used.
 - `border(&self) -> Option<SharedId<BorderView>>`:
   Get the border view added around the `WebviewWindow`.
+- `remove(&self)`:
+  Remove the border view from the `WebviewWindow`.
 
 ## BorderView
 The view that adds border around the `WebviewWindow`.


### PR DESCRIPTION
This pull request includes a small change to the `libs/border/README.md` file. The change adds a new method to the `WebviewWindowExt` trait for removing the border view from the `WebviewWindow`.

* [`libs/border/README.md`](diffhunk://#diff-dffda44c262e5374ea5cc3284337355b5d99d750120cf42d9231d576ea92aec6R99-R100): Added a description for the new `remove(&self)` method to the `WebviewWindowExt` trait.